### PR TITLE
Consumer for RSAM amplitude analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,4 @@ dmypy.json
 
 # vscode
 .vscode
+/.idea/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 # Changelog
+## changes in 1.0.1
+- added `rsudp.c_rsam` Real-time Seismic Analysis Measurement consumer 
+
 ## changes in 1.0.0
 - settings changed to deconvolve plot channels by default
 - added the ability to post to multiple Telegram chats (by spinning up multiple independent threads)

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 Boaz, Richard
 Nesbitt, Ian M.
+Long, Justin (@crockpotveggies)

--- a/rsudp/c_rsam.py
+++ b/rsudp/c_rsam.py
@@ -36,6 +36,7 @@ class RSAM(rs.ConsumerThread):
 		self.sender = 'RSAM'
 		self.alive = True
 		self.debug = debug
+		self.stn = rs.stn
 		self.fwaddr = fwaddr
 		self.fwport = fwport
 		self.fwformat = fwformat.upper()
@@ -195,13 +196,13 @@ class RSAM(rs.ConsumerThread):
 		Send the RSAM analysis via UDP to another destination in a lightweight format
 		"""
 		if self.sock:
-			msg = 'ch:%s|mean:%s|med:%s|min:%s|max:%s' % (self.cha, self.rsam[0], self.rsam[1], self.rsam[2], self.rsam[3])
+			msg = 'stn:%s|ch:%s|mean:%s|med:%s|min:%s|max:%s' % (self.stn, self.cha, self.rsam[0], self.rsam[1], self.rsam[2], self.rsam[3])
 			if self.fwformat is 'JSON':
-				msg = '{"channel":"%s","mean":%s,"median":%s,"min":%s,"max":%s}' \
-					  % (self.cha, self.rsam[0], self.rsam[1], self.rsam[2], self.rsam[3])
+				msg = '{"station":"%s","channel":"%s","mean":%s,"median":%s,"min":%s,"max":%s}' \
+					  % (self.stn, self.cha, self.rsam[0], self.rsam[1], self.rsam[2], self.rsam[3])
 			elif self.fwformat is 'CSV':
-				msg = '%s,%s,%s,%s,%s' \
-					  % (self.cha, self.rsam[0], self.rsam[1], self.rsam[2], self.rsam[3])
+				msg = '%s,%s,%s,%s,%s,%s' \
+					  % (self.stn, self.cha, self.rsam[0], self.rsam[1], self.rsam[2], self.rsam[3])
 			packet = bytes(msg, 'utf-8')
 			self.sock.sendto(packet, (self.fwaddr, self.fwport))
 
@@ -248,7 +249,9 @@ class RSAM(rs.ConsumerThread):
 					next_int = time.time() + self.interval
 
 			elif n == 0:
-				printM('Starting RSAM analysis with interval=%s on channel=%s' % (self.interval, self.cha), self.sender)
+				printM('Starting RSAM analysis with interval=%s on station=%s channel=%s forward=%s' %
+					   (self.interval, self.stn, self.cha, self.fwaddr),
+					   self.sender)
 			elif n == wait_pkts:
 				printM('RSAM analysis up and running normally.', self.sender)
 			else:

--- a/rsudp/c_rsam.py
+++ b/rsudp/c_rsam.py
@@ -1,0 +1,226 @@
+import sys, time
+from datetime import datetime, timedelta
+import statistics
+from rsudp import printM, printW, printE
+from rsudp import helpers
+import rsudp.raspberryshake as rs
+COLOR = {}
+from rsudp import COLOR
+
+# set the terminal text color to green
+COLOR['current'] = COLOR['green']
+
+class RSAM(rs.ConsumerThread):
+	"""
+	.. versionadded:: 1.0.0
+
+	A consumer class that runs an Real-time Seismic Analysis Measurement (RSAM).
+
+	:param queue.Queue q: queue of data and messages sent by :class:`rsudp.c_consumer.Consumer`.
+	:param bool debug: whether or not to display RSAM analysis live to the console.
+	:param float interval: window of time in seconds to apply RSAM analysis.
+	:param str cha: listening channel (defaults to [S,E]HZ)
+	:param str deconv: ``'VEL'``, ``'ACC'``, ``'GRAV'``, ``'DISP'``, or ``'CHAN'``
+	"""
+
+	def __init__(self, q=False, debug=False, interval=5, cha='HZ', deconv=False, *args, **kwargs):
+		"""
+		Initializes the RSAM analysis thread.
+		"""
+		super().__init__()
+		self.sender = 'RSAM'
+		self.alive = True
+		self.debug = debug
+		self.interval = interval
+		self.default_ch = 'HZ'
+		self.args = args
+		self.kwargs = kwargs
+		self.raw = rs.Stream()
+		self.stream = rs.Stream()
+		self.units = 'counts'
+
+		self._set_deconv(deconv)
+
+		self._set_channel(cha)
+
+		self.rsam = [1, 1, 1]
+
+		if q:
+			self.queue = q
+		else:
+			printE('no queue passed to the consumer thread! We will exit now!',
+				   self.sender)
+			sys.stdout.flush()
+			self.alive = False
+			sys.exit()
+
+		printM('Starting.', self.sender)
+
+
+	def _set_deconv(self, deconv):
+		"""
+		This function sets the deconvolution units. Allowed values are as follows:
+
+		.. |ms2| replace:: m/s\ :sup:`2`\
+
+		- ``'VEL'`` - velocity (m/s)
+		- ``'ACC'`` - acceleration (|ms2|)
+		- ``'GRAV'`` - fraction of acceleration due to gravity (g, or 9.81 |ms2|)
+		- ``'DISP'`` - displacement (m)
+		- ``'CHAN'`` - channel-specific unit calculation, i.e. ``'VEL'`` for geophone channels and ``'ACC'`` for accelerometer channels
+
+		:param str deconv: ``'VEL'``, ``'ACC'``, ``'GRAV'``, ``'DISP'``, or ``'CHAN'``
+		"""
+		deconv = deconv.upper() if deconv else False
+		self.deconv = deconv if (deconv in rs.UNITS) else False
+		if self.deconv and rs.inv:
+			self.units = '%s (%s)' % (rs.UNITS[self.deconv][0], rs.UNITS[self.deconv][1]) if (self.deconv in rs.UNITS) else self.units
+			printM('Signal deconvolution set to %s' % (self.deconv), self.sender)
+		else:
+			self.units = rs.UNITS['CHAN'][1]
+			self.deconv = False
+		printM('RSAM stream units are %s' % (self.units.strip(' ').lower()), self.sender)
+
+
+	def _find_chn(self):
+		"""
+		Finds channel match in list of channels.
+		"""
+		for chn in rs.chns:
+			if self.cha in chn:
+				self.cha = chn
+
+
+	def _set_channel(self, cha):
+		"""
+		This function sets the channel to listen to. Allowed values are as follows:
+
+		- "SHZ"``, ``"EHZ"``, ``"EHN"`` or ``"EHE"`` - velocity channels
+		- ``"ENZ"``, ``"ENN"``, ``"ENE"`` - acceleration channels
+		- ``"HDF"`` - pressure transducer channel
+		- ``"all"`` - resolves to either ``"EHZ"`` or ``"SHZ"`` if available
+
+		:param cha: the channel to listen to
+		:type cha: str
+		"""
+		cha = self.default_ch if (cha == 'all') else cha
+		self.cha = cha if isinstance(cha, str) else cha[0]
+
+		if self.cha in str(rs.chns):
+			self._find_chn()
+		else:
+			printE('Could not find channel %s in list of channels! Please correct and restart.' % self.cha, self.sender)
+			sys.exit(2)
+
+
+	def _getq(self):
+		"""
+		Reads data from the queue and updates the stream.
+
+		:rtype: bool
+		:return: Returns ``True`` if stream is updated, otherwise ``False``.
+		"""
+		d = self.queue.get(True, timeout=None)
+		self.queue.task_done()
+		if self.cha in str(d):
+			self.raw = rs.update_stream(stream=self.raw, d=d, fill_value='latest')
+			return True
+		elif 'TERM' in str(d):
+			self.alive = False
+			printM('Exiting.', self.sender)
+			sys.exit()
+		else:
+			return False
+
+
+	def _deconvolve(self):
+		"""
+		Deconvolves the stream associated with this class.
+		"""
+		if self.deconv:
+			helpers.deconvolve(self)
+
+
+	def _subloop(self):
+		"""
+		Gets the queue and figures out whether or not the specified channel is in the packet.
+		"""
+		while True:
+			if self.queue.qsize() > 0:
+				self._getq()			# get recent packets
+			else:
+				if self._getq():		# is this the specified channel? if so break
+					break
+
+
+	def _rsam(self):
+		"""
+		Run the RSAM analysis
+		"""
+		arr = [abs(el) for el in self.stream[0].data]
+		minv = min(arr)
+		maxv = max(arr)
+		meanv = statistics.mean(arr)
+		self.rsam = [minv, maxv, meanv]
+
+
+	def _print_rsam(self):
+		"""
+		Print the current RSAM analysis
+		"""
+		if self.debug:
+			msg = '%s [%s] Current RSAM: min %s max %s mean %s' % (
+				(self.stream[0].stats.starttime + timedelta(seconds=
+															len(self.stream[0].data) * self.stream[0].stats.delta)).strftime('%Y-%m-%d %H:%M:%S'),
+				self.sender,
+				self.rsam[0],
+				self.rsam[1],
+				self.rsam[2],
+			)
+			printM(msg, self.sender)
+
+
+	def run(self):
+		"""
+		Reads data from the queue and executes self.codefile if it sees an ``ALARM`` message.
+		Quits if it sees a ``TERM`` message.
+		"""
+		n = 0
+		next_int = time.time() + self.interval
+
+		wait_pkts = self.interval / (rs.tf / 1000)
+
+		while n > 3:
+			self.getq()
+			n += 1
+
+		n = 0
+		while True:
+			self._subloop()
+
+			self.raw = rs.copy(self.raw)	# necessary to avoid memory leak
+			self.stream = self.raw.copy()
+			self._deconvolve()
+
+			if n > wait_pkts:
+				# if the trigger is activated
+				obstart = self.stream[0].stats.endtime - timedelta(seconds=self.interval)	# obspy time
+				self.raw = self.raw.slice(starttime=obstart)		# slice the stream to the specified length (seconds variable)
+				self.stream = self.stream.slice(starttime=obstart)	# slice the stream to the specified length (seconds variable)
+
+				# run rsam analysis
+				if time.time() > next_int:
+					self._rsam()
+					self.stream = rs.copy(self.stream)  # prevent mem leak
+					self._print_rsam()
+					next_int = time.time() + self.interval
+
+			elif n == 0:
+				printM('Starting RSAM analysis with interval=%s on channel=%s' % (self.interval, self.cha), self.sender)
+			elif n == wait_pkts:
+				printM('RSAM analysis up and running normally.', self.sender)
+			else:
+				pass
+
+			n += 1
+			sys.stdout.flush()

--- a/rsudp/client.py
+++ b/rsudp/client.py
@@ -331,6 +331,7 @@ def run(settings, debug):
 		# put settings in namespace
 		fwaddr = settings['rsam']['fwaddr']
 		fwport = settings['rsam']['fwport']
+		fwformat = settings['rsam']['fwformat']
 		interval = settings['rsam']['interval']
 		cha = settings['rsam']['channel']
 		if settings['rsam']['deconvolve']:
@@ -343,7 +344,7 @@ def run(settings, debug):
 
 		# set up queue and process
 		q = mk_q()
-		rsam = RSAM(q=q, debug=debug, interval=interval, cha=cha, deconv=deconv, fwaddr=fwaddr, fwport=fwport)
+		rsam = RSAM(q=q, debug=debug, interval=interval, cha=cha, deconv=deconv, fwaddr=fwaddr, fwport=fwport, fwformat=fwformat)
 
 		mk_p(rsam)
 

--- a/rsudp/client.py
+++ b/rsudp/client.py
@@ -24,6 +24,7 @@ from rsudp.c_alertsound import AlertSound
 from rsudp.c_custom import Custom
 from rsudp.c_tweet import Tweeter
 from rsudp.c_telegram import Telegrammer
+from rsudp.c_rsam import RSAM
 from rsudp.c_testing import Testing
 from rsudp.t_testdata import TestData
 import pkg_resources as pr
@@ -325,6 +326,24 @@ def run(settings, debug):
 								   send_images=send_images,
 								   sender=sender)
 			mk_p(telegram)
+
+	if settings['rsam']['enabled']:
+		# put settings in namespace
+		interval = settings['rsam']['interval']
+		cha = settings['rsam']['channel']
+		if settings['rsam']['deconvolve']:
+			if settings['rsam']['units'].upper() in rs.UNITS:
+				deconv = settings['rsam']['units'].upper()
+			else:
+				deconv = 'CHAN'
+		else:
+			deconv = False
+
+		# set up queue and process
+		q = mk_q()
+		rsam = RSAM(q=q, debug=debug, interval=interval, cha=cha, deconv=deconv)
+
+		mk_p(rsam)
 
 
 	# start additional modules here!

--- a/rsudp/client.py
+++ b/rsudp/client.py
@@ -329,6 +329,8 @@ def run(settings, debug):
 
 	if settings['rsam']['enabled']:
 		# put settings in namespace
+		fwaddr = settings['rsam']['fwaddr']
+		fwport = settings['rsam']['fwport']
 		interval = settings['rsam']['interval']
 		cha = settings['rsam']['channel']
 		if settings['rsam']['deconvolve']:
@@ -341,7 +343,7 @@ def run(settings, debug):
 
 		# set up queue and process
 		q = mk_q()
-		rsam = RSAM(q=q, debug=debug, interval=interval, cha=cha, deconv=deconv)
+		rsam = RSAM(q=q, debug=debug, interval=interval, cha=cha, deconv=deconv, fwaddr=fwaddr, fwport=fwport)
 
 		mk_p(rsam)
 

--- a/rsudp/helpers.py
+++ b/rsudp/helpers.py
@@ -81,7 +81,13 @@ def default_settings(output_dir='%s/rsudp' % os.path.expanduser('~').replace('\\
     "enabled": false,
     "send_images": true,
     "token": "n/a",
-    "chat_id": "n/a"}
+    "chat_id": "n/a"},
+"rsam": {
+    "enabled": false,
+    "channel": "HZ",
+    "interval": 10,
+    "deconvolve": false,
+    "units": "VEL"}
 }
 
 """ % (output_dir)

--- a/rsudp/helpers.py
+++ b/rsudp/helpers.py
@@ -86,6 +86,7 @@ def default_settings(output_dir='%s/rsudp' % os.path.expanduser('~').replace('\\
     "enabled": false,
     "fwaddr": false,
     "fwport": false,
+    "fwformat": "LITE",
     "channel": "HZ",
     "interval": 10,
     "deconvolve": false,

--- a/rsudp/helpers.py
+++ b/rsudp/helpers.py
@@ -84,6 +84,8 @@ def default_settings(output_dir='%s/rsudp' % os.path.expanduser('~').replace('\\
     "chat_id": "n/a"},
 "rsam": {
     "enabled": false,
+    "fwaddr": false,
+    "fwport": false,
     "channel": "HZ",
     "interval": 10,
     "deconvolve": false,

--- a/rsudp/test.py
+++ b/rsudp/test.py
@@ -61,6 +61,8 @@ def make_test_settings(settings, inet=False):
 	 ``settings['plot']['units']``            ``'CHAN'``
 	 ``settings['plot']['eq_screenshots']``   ``True``
 	 ``settings['alertsound']['enabled']``    ``True``
+	 ``settings['rsam']['enabled']``          ``True``
+	 ``settings['rsam']['debug']``            ``True``
 	======================================== ===================
 
 	.. note::
@@ -96,6 +98,10 @@ def make_test_settings(settings, inet=False):
 	settings['plot']['eq_screenshots'] = True
 
 	settings['alertsound']['enabled'] = True
+
+	settings['rsam']['enabled'] = True
+	settings['rsam']['debug'] = True
+	settings['rsam']['interval'] = 5
 
 	return settings
 

--- a/rsudp/test.py
+++ b/rsudp/test.py
@@ -102,6 +102,8 @@ def make_test_settings(settings, inet=False):
 	settings['rsam']['enabled'] = True
 	settings['rsam']['debug'] = True
 	settings['rsam']['interval'] = 5
+	settings['rsam']['fwaddr'] = "127.0.0.1"
+	settings['rsam']['fwport'] = 4444
 
 	return settings
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="rsudp",
-    version="1.0.0",
+    version="1.0.1",
     author="Ian Nesbitt",
     author_email="ian.nesbitt@raspberryshake.org",
     license='GPLv3',


### PR DESCRIPTION
Wrote a module for RSAM real-time seismic amplitude measurement analysis. The module allows the user to calculate mean, median, min, and max values over a specified time window and optionally forward it to another destination via UDP.

Example from running tests:

```
2020-04-18 03:39:32 TESTING [RSAM] RSAM analysis up and running normally.
2020-04-18 03:39:32 TESTING [RSAM] 2020-01-30 08:26:58 [RSAM] Current RSAM: mean 16280 median 16279 min 16134 max 16456
2020-04-18 03:39:37 TESTING [RSAM] 2020-01-30 08:27:03 [RSAM] Current RSAM: mean 16280 median 16280 min 16145 max 16410
2020-04-18 03:39:43 TESTING [RSAM] 2020-01-30 08:27:08 [RSAM] Current RSAM: mean 16282 median 16284 min 16159 max 16404
2020-04-18 03:39:48 TESTING [RSAM] 2020-01-30 08:27:13 [RSAM] Current RSAM: mean 16283 median 16285 min 16163 max 16418
```

The user can opt to forward RSAM in a lightweight format, JSON, or CSV.