### PR TITLE
Adding a consumer that calculates peak displacement P(d) after the sudden motion trigger is tripped

### DIFF
--- a/rsudp/c_pd.py
+++ b/rsudp/c_pd.py
@@ -1,0 +1,12 @@
+import os, sys
+import time
+import rsudp.raspberryshake as rs
+from rsudp import printM, printW, printE, helpers
+from rsudp.test import TEST
+
+class Pd(rs.ConsumerThread):
+	"""
+	.. versionadded:: 1.1.1
+
+	A consumer class that calculates peak amplitude of displacement P(d) when a trigger is set off.
+    """


### PR DESCRIPTION
From @gpetricca:

> The definition of P(d) can be found in this paper: https://www.mdpi.com/1424-8220/22/12/4534/pdf as “the maximum peak amplitude of displacement in the first three seconds after the calculated (or observed) arrival of the P waves to the receiving station.”
> 
> The new P(d) algorithm in RSUDP should do the following:
> 
>   - The trigger algorithm (like the one already built into RSUDP) detects an event (at time Tp). This also triggers the new P(d) algorithm.
>   - P(d) would gather data from the detection time (Tp) to Tp+3s.
>   - P(d) would then remove the instrument response to get displacement (with something akin to `stream.remove_response(inventory=inv, output="DISP")`.
>   - Finally, P(d) would calculate the max amplitude in the Tp to Tp+3s time window.

This will be done in a new consumer class that monitors the trigger messages sent via the queue. When a trigger message is received, the P(d) algorithm will send the P(d) calculation back through the queue and write it to the log output. There may be an option to send the P(d) calculation to an external server, depending on need.