### PR TITLE
New style telegram with asyncio

### DIFF
--- a/rsudp/c_telegram.py
+++ b/rsudp/c_telegram.py
@@ -183,4 +183,7 @@ class Telegrammer(rs.ConsumerThread):
 
 			elif 'IMGPATH' in str(d):
 #				Async send the image, sometimes it takes too long, so we need to create a potential grace of max 3 sec for the async loop to finish.
-				asyncio.run(asyncio.wait_for(self._when_img(d), 3))
+				try:
+					asyncio.run(asyncio.wait_for(self._when_img(d), 3))
+				except asyncio.TimeoutError as e: #if it completely times out, catch the error.
+					printE('Asyncio timeout error - %s' % (e))

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     include_package_data=True,
     install_requires=['obspy', 'numpy', 'matplotlib<3.2', 'pydub', 'twython',
-                      'python-telegram-bot<=13.11'],
+                      'python-telegram-bot'], # No need to pin the version with the new telegram code.
     entry_points = {
         'console_scripts': [
             'rs-packetloss=rsudp.packetloss:main',


### PR DESCRIPTION
as for issue #53, version >20.0 of the Telegram bot uses asyncio. This is at least one way of solving this. Most likely would be enough to use asyncio.run() on the bot call without making the whole definitions async, but this works too.