### PR TITLE
fix custom codefile execution syntax error

### DIFF
--- a/rsudp/c_custom.py
+++ b/rsudp/c_custom.py
@@ -91,7 +91,9 @@ class Custom(ConsumerThread):
 			printM('Executing code from file: %s' % self.codefile, sender=self.sender)
 			try:
 				# try to execute some code
-				exec(self.codefile)
+				with open(self.codefile, 'r') as file:
+					file_content = file.read()
+				exec(file_content)
 				if self.testing:
 					TEST['c_custom'][1] = True
 			except Exception as e:


### PR DESCRIPTION
I've seen this issue around, where when specifying a custom file the user gets back a syntax error. Tested and verified that the problem is that exec is being called on the filename instead of the file contents. The exec function is meant to execute a string of Python code, not to execute the file by its path. The exec command typically works like:

```
# Define the path to the file
file_path = 'YOURPATH'

# Read the content of the file
with open(file_path, 'r') as file:
    file_content = file.read()

# Execute the content of the file
exec(file_content)
```

but it's being called on `self.codefile` where `self.codefile` is the file path (and not the actual python code).  This would cause a syntax error since exec expects python code and not the file path -- which is exactly what we're seeing.

This fix should resolve this. Thanks!