### PR TITLE
Update/python3.12 Changes to work on Raspberry OS 64-bit

### DIFF
--- a/bin/unix-install.sh
+++ b/bin/unix-install.sh
@@ -139,13 +139,14 @@ if [ -z ${conda_exists+x} ]; then
     wget "$arm_base_url$arm_exe" -O "$tmp_exe" && dl=1
 
   else
-    if [[ "$arch" == "aarch64" ]]; then
-      conda_installer=$aarch64_exe
-      wget "$aarch64_base_url$conda_installer" -O "$tmp_exe" && dl=1
-
-    elif [[ "$os" == "Linux" ]]; then
-      conda_installer=$linux_exe
-      wget "$x86_base_url$conda_installer" -O "$tmp_exe" && dl=1
+    if [[ "$os" == "Linux" ]]; then
+      if [[ "$arch" == "aarch64" ]]; then
+        conda_installer=$aarch64_exe
+        wget "$aarch64_base_url$conda_installer" -O "$tmp_exe" && dl=1
+      else
+        conda_installer=$linux_exe
+        wget "$x86_base_url$conda_installer" -O "$tmp_exe" && dl=1
+      fi
 
     elif [[ "$os" == "Darwin" ]]; then
       conda_installer=$macos_exe

--- a/bin/unix-install.sh
+++ b/bin/unix-install.sh
@@ -21,6 +21,7 @@ if [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda
 # conda install location:
 prefix="$HOME/$release"         # $HOME/miniconda3 is default location
 full="$HOME/anaconda3"          # full release install location
+miniforge3="$HOME/miniforge3"   # MiniForge3
 berryconda="$HOME/berryconda3"  # berryconda install location
 miniconda="$HOME/miniconda3"    # miniconda install location
 config="$HOME/.config/rsudp"    # config location
@@ -76,6 +77,12 @@ if [ -z ${conda_exists+x} ]; then
   if [ -f "$miniconda/bin/conda" ]; then
     # now we look in the default install location
     . $prefix/etc/profile.d/conda.sh &&
+    conda activate &&
+    conda_exists=1
+  elif [ -f "$miniforge3/bin/conda" ]; then
+    # look for a miniforge3 release
+    . $miniforge3/etc/profile.d/conda.sh &&
+    prefix=$miniforge3
     conda activate &&
     conda_exists=1
   elif [ -f "$berryconda/bin/conda" ]; then

--- a/bin/unix-install.sh
+++ b/bin/unix-install.sh
@@ -14,10 +14,12 @@ conda="conda"       # anaconda executable or alias
 mpl="<3.2"          # matplotlib version
 macos_exe="Miniconda3-4.7.12-MacOSX-x86_64.sh"
 linux_exe="Miniconda3-py312_24.5.0-0-Linux-x86_64.sh"
+aarch64_exe="Miniforge3-Linux-aarch64.sh"
 arm_exe="Berryconda3-2.0.0-Linux-armv7l.sh"
 x86_base_url="https://repo.anaconda.com/miniconda/"
+aarch64_base_url="https://github.com/conda-forge/miniforge/releases/latest/download/"
 arm_base_url="https://github.com/jjhelmus/berryconda/releases/download/v2.0.0/"
-if [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda3'; fi
+if [[ "$arch" == "aarch64" ]]; then release='miniforge3'; elif [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda3'; fi
 # conda install location:
 prefix="$HOME/$release"         # $HOME/miniconda3 is default location
 full="$HOME/anaconda3"          # full release install location
@@ -137,7 +139,11 @@ if [ -z ${conda_exists+x} ]; then
     wget "$arm_base_url$arm_exe" -O "$tmp_exe" && dl=1
 
   else
-    if [[ "$os" == "Linux" ]]; then
+    if [[ "$arch" == "aarch64" ]]; then
+      conda_installer=$aarch64_exe
+      wget "$aarch64_base_url$conda_installer" -O "$tmp_exe" && dl=1
+
+    elif [[ "$os" == "Linux" ]]; then
       conda_installer=$linux_exe
       wget "$x86_base_url$conda_installer" -O "$tmp_exe" && dl=1
 

--- a/bin/unix-update.sh
+++ b/bin/unix-update.sh
@@ -8,7 +8,7 @@ os=$(uname -s)      # kernel name
 node=$(uname -n)    # node name
 bsd=$(uname -a | grep BSD || uname -a | grep Darwin)  # is this a BSD variant?
 conda="conda"       # anaconda executable or alias
-if [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda3'; fi
+if [[ "$arch" == "aarch64" ]]; then release='miniforge3'; elif [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda3'; fi
 # conda install location:
 prefix="$HOME/$release"         # $HOME/miniconda3 is default location
 full="$HOME/anaconda3"          # full release install location

--- a/bin/unix-update.sh
+++ b/bin/unix-update.sh
@@ -12,6 +12,7 @@ if [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda
 # conda install location:
 prefix="$HOME/$release"         # $HOME/miniconda3 is default location
 full="$HOME/anaconda3"          # full release install location
+miniforge3="$HOME/miniforge3"   # MiniForge3
 berryconda="$HOME/berryconda3"  # berryconda install location
 miniconda="$HOME/miniconda3"    # miniconda install location
 config="$HOME/.config/rsudp"    # config location
@@ -58,6 +59,12 @@ if [ -z ${conda_exists+x} ]; then
   if [ -f "$miniconda/bin/conda" ]; then
     # now we look in the default install location
     . $prefix/etc/profile.d/conda.sh &&
+    conda activate &&
+    conda_exists=1
+  elif [ -f "$miniforge3/bin/conda" ]; then
+    # look for a miniforge3 release
+    . $miniforge3/etc/profile.d/conda.sh &&
+    prefix=$miniforge3
     conda activate &&
     conda_exists=1
   elif [ -f "$berryconda/bin/conda" ]; then

--- a/rsudp/c_plot.py
+++ b/rsudp/c_plot.py
@@ -413,10 +413,10 @@ class Plot:
 							  )-np.timedelta64(self.seconds, 's')	# numpy time
 		end = np.datetime64(self.stream[0].stats.endtime)	# numpy time
 
-		#im = mpimg.imread(pr.resource_filename('rsudp', os.path.join('img', 'version1-01-small.png')))
-		#self.imax = self.fig.add_axes([0.015, 0.944, 0.2, 0.056], anchor='NW') # [left, bottom, right, top]
-		#self.imax.imshow(im, aspect='equal', interpolation='sinc')
-		#self.imax.axis('off')
+		im = mpimg.imread(pr.resource_filename('rsudp', os.path.join('img', 'version1-01-small.png')))
+		self.imax = self.fig.add_axes([0.015, 0.944, 0.2, 0.056], anchor='NW') # [left, bottom, right, top]
+		self.imax.imshow(im, aspect='equal', interpolation='sinc')
+		self.imax.axis('off')
 		# set up axes and artists
 		for i in range(self.num_chans): # create lines objects and modify axes
 			if len(self.stream[i].data) < int(self.sps*(1/self.per_lap)):

--- a/rsudp/c_plot.py
+++ b/rsudp/c_plot.py
@@ -413,10 +413,10 @@ class Plot:
 							  )-np.timedelta64(self.seconds, 's')	# numpy time
 		end = np.datetime64(self.stream[0].stats.endtime)	# numpy time
 
-		im = mpimg.imread(pr.resource_filename('rsudp', os.path.join('img', 'version1-01-small.png')))
-		self.imax = self.fig.add_axes([0.015, 0.944, 0.2, 0.056], anchor='NW') # [left, bottom, right, top]
-		self.imax.imshow(im, aspect='equal', interpolation='sinc')
-		self.imax.axis('off')
+		#im = mpimg.imread(pr.resource_filename('rsudp', os.path.join('img', 'version1-01-small.png')))
+		#self.imax = self.fig.add_axes([0.015, 0.944, 0.2, 0.056], anchor='NW') # [left, bottom, right, top]
+		#self.imax.imshow(im, aspect='equal', interpolation='sinc')
+		#self.imax.axis('off')
 		# set up axes and artists
 		for i in range(self.num_chans): # create lines objects and modify axes
 			if len(self.stream[i].data) < int(self.sps*(1/self.per_lap)):

--- a/unix-install-rsudp.sh
+++ b/unix-install-rsudp.sh
@@ -3,7 +3,7 @@
 dir_name="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" # current directory
 arch=$(uname -m)    # machine hardware 
 conda="conda"       # anaconda executable or alias
-if [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda3'; fi
+if [[ "$arch" == "aarch64" ]]; then release='miniforge3'; elif [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda3'; fi
 # conda install location:
 prefix="$HOME/$release"         # $HOME/miniconda3 is default location
 full="$HOME/anaconda3"          # full release install location

--- a/unix-install-rsudp.sh
+++ b/unix-install-rsudp.sh
@@ -7,6 +7,7 @@ if [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda
 # conda install location:
 prefix="$HOME/$release"         # $HOME/miniconda3 is default location
 full="$HOME/anaconda3"          # full release install location
+miniforge3="$HOME/miniforge3"   # MiniForge3
 berryconda="$HOME/berryconda3"  # berryconda install location
 miniconda="$HOME/miniconda3"    # miniconda install location
 config="$HOME/.config/rsudp"    # config location
@@ -25,6 +26,12 @@ if [ -z ${conda_exists+x} ]; then
   if [ -f "$miniconda/bin/conda" ]; then
     # now we look in the default install location
     . $prefix/etc/profile.d/conda.sh &&
+    conda activate &&
+    conda_exists=1
+  elif [ -f "$miniforge3/bin/conda" ]; then
+    # look for a miniforge3 release
+    . $miniforge3/etc/profile.d/conda.sh &&
+    prefix=$miniforge3
     conda activate &&
     conda_exists=1
   elif [ -f "$berryconda/bin/conda" ]; then

--- a/unix-start-rsudp.sh
+++ b/unix-start-rsudp.sh
@@ -10,11 +10,14 @@ if [[ "$arch" == "armv"* ]]; then release='berryconda3'; else release='miniconda
 # conda install location:
 prefix="$HOME/$release"         # $HOME/miniconda3 is default location
 full="$HOME/anaconda3"          # full release install location
+miniforge3="$HOME/miniforge3"   # MiniForge3
 
 if [ -f "$prefix/etc/profile.d/conda.sh" ]; then
   . $prefix/etc/profile.d/conda.sh
 elif [ -f "$full/etc/profile.d/conda.sh" ]; then
   . $full/etc/profile.d/conda.sh
+  elif [ -f "$miniforge3/bin/conda" ]; then
+  . $miniforge3/etc/profile.d/conda.sh
 else
   echo "Could not find an anaconda installation. Have you used the installer script to install rsudp, or is anaconda in a nonstandard location?"
   exit 2


### PR DESCRIPTION
This PR recognizes aarch64 and, if found, installs aarch64 miniforge3.  As such, installs now work correctly on Raspberry Pi OS 64-bit.

Tested install where miniforge3 must be installed.

Also tested where miniforge3 was pre-installed in $HOME/miniforge3

I’m sending this PR in case you want it.  I won’t be offended if you don’t take it.  I’m happy because I can finally decommission my Pi that was running an old 32-bit Raspberry Pi OS just to run rsudp.